### PR TITLE
ci: refactor cibuldwheel code

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -25,7 +25,7 @@ jobs:
       uses: pypa/cibuildwheel@v2.6.1
       env:
         CIBW_BEFORE_ALL: >
-          cmake
+          cmake python
       with:
         package-dir: python
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -26,7 +26,7 @@ jobs:
       env:
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
         CIBW_BEFORE_ALL: >
-          dnf install -y cython3 &&
+          dnf install -y $(grep "^[^#]" dependencies.txt) &&
           cd python && cmake .
       with:
         package-dir: python

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -3,6 +3,7 @@ name: Python Package
 on:
   release:
     types: [published]
+  push:
   workflow_dispatch:
 
 
@@ -18,7 +19,8 @@ jobs:
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.6.1
       env:
-        CIBW_BEFORE_BUILD: cmake
+        CIBW_BEFORE_ALL: >
+          cmake
       with:
         package-dir: python
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -25,7 +25,7 @@ jobs:
       uses: pypa/cibuildwheel@v2.6.1
       env:
         CIBW_BEFORE_ALL: >
-          cmake python
+          cd python && cmake .
       with:
         package-dir: python
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,36 @@
+name: Python Package
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+
+permissions:
+  contents: read
+
+jobs:
+  build_wheels:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.6.1
+      # to supply options, put them in 'env', like:
+      # env:
+      #   CIBW_SOME_OPTION: value
+
+    - uses: actions/upload-artifact@v2
+      with:
+        path: ./wheelhouse/*.whl
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build_wheels
+    steps:
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,9 +17,8 @@ jobs:
 
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.6.1
-      # to supply options, put them in 'env', like:
-      # env:
-      #   CIBW_SOME_OPTION: value
+      env:
+        CIBW_BEFORE_BUILD: cmake
       with:
         package-dir: python
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -26,7 +26,6 @@ jobs:
       env:
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
         CIBW_BEFORE_ALL: >
-          dnf install -y $(grep "^[^#]" dependencies.txt) &&
           pip install Cython &&
           cd python && cmake .
       with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -15,6 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    
+    - name: Stub `setup.py` check
+      # It will be generated during CMake run
+      # https://github.com/pypa/cibuildwheel/issues/1139
+      run: touch python/setup.py
 
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.6.1

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -26,7 +26,8 @@ jobs:
       env:
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
         CIBW_BEFORE_ALL: >
-          dnf install -y $(grep "^[^#]" dependencies.txt) &&
+          # dnf install -y $(grep "^[^#]" dependencies.txt) &&
+          pip install Cython &&
           cd python && cmake .
       with:
         package-dir: python

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -24,6 +24,7 @@ jobs:
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.7.0
       env:
+        CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
         CIBW_BEFORE_ALL: >
           dnf install -y cython3 &&
           cd python && cmake .

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,6 +20,8 @@ jobs:
       # to supply options, put them in 'env', like:
       # env:
       #   CIBW_SOME_OPTION: value
+      with:
+        package-dir: python
 
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -26,7 +26,7 @@ jobs:
       env:
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
         CIBW_BEFORE_ALL: >
-          # dnf install -y $(grep "^[^#]" dependencies.txt) &&
+          dnf install -y $(grep "^[^#]" dependencies.txt) &&
           pip install Cython &&
           cd python && cmake .
       with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -25,7 +25,7 @@ jobs:
       uses: pypa/cibuildwheel@v2.7.0
       env:
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
-        CIBW_BEFORE_ALL: >
+        CIBW_BEFORE_BUILD: >
           pip install Cython &&
           cd python && cmake .
       with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -24,7 +24,8 @@ jobs:
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.6.1
       env:
-        CIBW_BEFORE_ALL: >
+        CIBW_BEFORE_ALL: |
+          apt-get -y install cython3
           cd python && cmake .
       with:
         package-dir: python

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -22,10 +22,10 @@ jobs:
       run: touch python/setup.py
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.6.1
+      uses: pypa/cibuildwheel@v2.7.0
       env:
-        CIBW_BEFORE_ALL: |
-          apt-get -y install cython3
+        CIBW_BEFORE_ALL: >
+          dnf install -y cython3 &&
           cd python && cmake .
       with:
         package-dir: python

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -27,7 +27,7 @@ jobs:
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
         CIBW_BEFORE_BUILD: >
           pip install Cython &&
-          cd python && cmake .
+          cmake .
       with:
         package-dir: python
 

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -52,7 +52,7 @@ jobs:
 
     - uses: actions/upload-artifact@v3
       with:
-        name: linux-wheels
+        name: opendht-wheels-linux
         path: ./wheelhouse/*.whl
 
   publish:
@@ -61,7 +61,7 @@ jobs:
     steps:
     - uses: actions/download-artifact@v3
       with:
-        name: linux-wheels
+        name: opendht-wheels-linux
 
     - name: Publish package
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -33,7 +33,7 @@ jobs:
           dnf install -y $(grep "^[^#]" dependencies.txt)
         CIBW_BEFORE_BUILD: >
           pip install Cython &&
-          cmake .
+          cmake -DOPENDHT_PYTHON=ON .
       with:
         package-dir: python
 

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -24,6 +24,8 @@ jobs:
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.7.0
       env:
+        CIBW_BUILD: cp39-* cp310-*
+        CIBW_ARCHS: x86_64
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
         # installing packages in AlmaLinux is a quest
         # https://bugs.almalinux.org/view.php?id=208&nbn=3

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -26,6 +26,7 @@ jobs:
       env:
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
         CIBW_BEFORE_ALL: >
+          dnf install -y epel-release &&
           dnf install -y $(grep "^[^#]" dependencies.txt)
         CIBW_BEFORE_BUILD: >
           pip install Cython &&

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -33,7 +33,8 @@ jobs:
           dnf install -y $(grep "^[^#]" dependencies.txt)
         CIBW_BEFORE_BUILD: >
           pip install Cython &&
-          cmake -DOPENDHT_PYTHON=ON .
+          cmake -DOPENDHT_PYTHON=ON . &&
+          make
       with:
         package-dir: python
 

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -45,7 +45,7 @@ jobs:
           make
         # The way to point `auditwheel` to "libopendht.so.2" in the current dir
         CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
-          LD_LIBRARY_PATH=. auditwheel repair -w {dest_dir} {wheel}
+          LD_LIBRARY_PATH=$PWD auditwheel repair -w {dest_dir} {wheel}
       with:
         package-dir: python
 

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -50,14 +50,19 @@ jobs:
       with:
         package-dir: python
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
+        name: linux-wheels
         path: ./wheelhouse/*.whl
 
   publish:
     runs-on: ubuntu-latest
     needs: build_wheels
     steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: linux-wheels
+
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -64,6 +64,7 @@ jobs:
         name: linux-wheels
 
     - name: Publish package
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -24,8 +24,7 @@ jobs:
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.7.0
       env:
-        CIBW_BUILD: cp39-* cp310-*
-        CIBW_ARCHS: x86_64
+        CIBW_BUILD: cp3{9,10}-manylinux_x86_64
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
         # installing packages in AlmaLinux is a quest
         # https://bugs.almalinux.org/view.php?id=208&nbn=3

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -30,7 +30,15 @@ jobs:
         CIBW_BEFORE_ALL: >
           dnf install -y epel-release &&
           dnf module enable -y mariadb-devel &&
-          dnf install -y $(grep "^[^#]" dependencies.txt)
+          dnf install -y $(grep "^[^#]" dependencies.txt) &&
+          echo "need newer asio-devel version" &&
+            curl -OL https://download.sourceforge.net/asio/asio-1.21.0.tar.bz2 &&
+            tar xf asio-1.21.0.tar.bz2 &&
+            cd asio-1.21.0 &&
+            ./configure &&
+            make &&
+            make install &&
+            cd ..
         CIBW_BEFORE_BUILD: >
           pip install Cython &&
           cmake -DOPENDHT_PYTHON=ON . &&

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -25,6 +25,8 @@ jobs:
       uses: pypa/cibuildwheel@v2.7.0
       env:
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+        CIBW_BEFORE_ALL: >
+          dnf install -y $(grep "^[^#]" dependencies.txt)
         CIBW_BEFORE_BUILD: >
           pip install Cython &&
           cmake .

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -25,8 +25,11 @@ jobs:
       uses: pypa/cibuildwheel@v2.7.0
       env:
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+        # installing packages in AlmaLinux is a quest
+        # https://bugs.almalinux.org/view.php?id=208&nbn=3
         CIBW_BEFORE_ALL: >
           dnf install -y epel-release &&
+          dnf module enable -y mariadb-devel &&
           dnf install -y $(grep "^[^#]" dependencies.txt)
         CIBW_BEFORE_BUILD: >
           pip install Cython &&

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -43,6 +43,9 @@ jobs:
           pip install Cython &&
           cmake -DOPENDHT_PYTHON=ON . &&
           make
+        # The way to point `auditwheel` to "libopendht.so.2" in the current dir
+        CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
+          LD_LIBRARY_PATH=. auditwheel repair -w {dest_dir} {wheel}
       with:
         package-dir: python
 

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -15,44 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    
-    - name: Stub `setup.py` check
-      # It will be generated during CMake run
-      # https://github.com/pypa/cibuildwheel/issues/1139
-      run: touch python/setup.py
 
+      # You can run locally on any machine with docker using: pipx run cibuildwheel --platform linux python
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.7.0
-      env:
-        CIBW_BUILD: cp3{9,10}-manylinux_x86_64
-        CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
-        # installing packages in AlmaLinux is a quest
-        # https://bugs.almalinux.org/view.php?id=208&nbn=3
-        CIBW_BEFORE_ALL: >
-          dnf install -y epel-release &&
-          dnf module enable -y mariadb-devel &&
-          dnf install -y $(grep "^[^#]" dependencies.txt) &&
-          echo "need newer asio-devel version" &&
-            curl -OL https://download.sourceforge.net/asio/asio-1.21.0.tar.bz2 &&
-            tar xf asio-1.21.0.tar.bz2 &&
-            cd asio-1.21.0 &&
-            ./configure &&
-            make &&
-            make install &&
-            cd ..
-        CIBW_BEFORE_BUILD: >
-          pip install Cython &&
-          cmake -DOPENDHT_PYTHON=ON . &&
-          make
-        # The way to point `auditwheel` to "libopendht.so.2" in the current dir
-        CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
-          LD_LIBRARY_PATH=$PWD auditwheel repair -w {dest_dir} {wheel}
       with:
         package-dir: python
 
     - uses: actions/upload-artifact@v3
       with:
-        name: opendht-wheels-linux
+        name: opendht-wheels
         path: ./wheelhouse/*.whl
 
   publish:
@@ -61,11 +33,11 @@ jobs:
     steps:
     - uses: actions/download-artifact@v3
       with:
-        name: opendht-wheels-linux
+        name: opendht-wheels
+        path: dist
 
     - name: Publish package
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,0 +1,7 @@
+# System dependencies for building OpenDHT wheels on AlmaLinux
+#
+#   dnf install -y $(grep "^[^#]" dependencies.txt)
+#     or
+#   apt-get -y install $(grep "^[^#]" dependencies.txt)a
+
+python3-Cython

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -8,3 +8,4 @@ gnutls-devel
 msgpack-devel
 readline-devel
 libargon2-devel
+asio-devel

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,6 +1,0 @@
-# System dependencies for building OpenDHT wheels on AlmaLinux
-#
-#   dnf install -y $(grep "^[^#]" dependencies.txt)
-#     or
-#   apt-get -y install $(grep "^[^#]" dependencies.txt)a
-

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,0 +1,8 @@
+# System dependencies for building OpenDHT wheels on AlmaLinux
+#
+#   dnf install -y $(grep "^[^#]" dependencies.txt)
+#     or
+#   apt-get -y install $(grep "^[^#]" dependencies.txt)a
+
+gnutls-devel
+msgpack-devel

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -7,3 +7,4 @@
 gnutls-devel
 msgpack-devel
 readline-devel
+libargon2-devel

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -4,4 +4,3 @@
 #     or
 #   apt-get -y install $(grep "^[^#]" dependencies.txt)a
 
-python3-Cython

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -6,3 +6,4 @@
 
 gnutls-devel
 msgpack-devel
+readline-devel

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,8 +1,6 @@
 # System dependencies for building OpenDHT wheels on AlmaLinux
 #
 #   dnf install -y $(grep "^[^#]" dependencies.txt)
-#     or
-#   apt-get -y install $(grep "^[^#]" dependencies.txt)a
 
 gnutls-devel
 msgpack-devel

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=42", "cython", "cmake"]
+build-backend = "setuptools.build_meta"
+
+[tool.cibuildwheel]
+build = 'cp3{9,10}-manylinux_x86_64'
+manylinux-x86_64-image = 'manylinux_2_28'
+before-all = [
+  'dnf install -y epel-release',
+  'dnf module enable -y mariadb-devel',
+  'dnf install -y $(grep "^[^#]" dependencies.txt)',
+  'echo "need newer asio-devel version"',
+  'curl -OL https://download.sourceforge.net/asio/asio-1.21.0.tar.bz2',
+  'tar xf asio-1.21.0.tar.bz2',
+  'cd asio-1.21.0',
+  './configure',
+  'make',
+  'make install',
+]
+before-build = [
+    'pip install cython',  # Required for configure check
+    'cmake -DOPENDHT_PYTHON=ON .',
+    'cmake --build .',
+]
+
+# The way to point `auditwheel` to "libopendht.so.2" in the current dir
+linux.repair-wheel-command = 'LD_LIBRARY_PATH=$PWD auditwheel repair -w {dest_dir} {wheel}'

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -22,8 +22,6 @@
 #
 
 from setuptools import setup, Extension
-from Cython.Build import cythonize
-from Cython.Distutils import build_ext
 
 setup(name="opendht",
       version="@PACKAGE_VERSION@",
@@ -44,15 +42,16 @@ setup(name="opendht",
           'Programming Language :: Python :: 3.4',
           'Programming Language :: Python :: 3.5',
       ],
-      cmdclass = { 'build_ext' : build_ext },
-      ext_modules = cythonize(Extension(
-          "opendht",
-          ["@CURRENT_SOURCE_DIR@/opendht.pyx"],
-          include_dirs = ['@PROJECT_SOURCE_DIR@/include'],
-          language="c++",
-          extra_compile_args=["-std=c++17"],
-          extra_link_args=["-std=c++17"],
-          libraries=["opendht"],
-          library_dirs = ['@CURRENT_BINARY_DIR@', '@PROJECT_BINARY_DIR@']
-      ))
+      ext_modules = [
+          Extension(
+              "opendht",
+              ["@CURRENT_SOURCE_DIR@/opendht.pyx"],
+              include_dirs = ['@PROJECT_SOURCE_DIR@/include'],
+              language="c++",
+              extra_compile_args=["-std=c++17"],
+              extra_link_args=["-std=c++17"],
+              libraries=["opendht"],
+              library_dirs = ['@CURRENT_BINARY_DIR@', '@PROJECT_BINARY_DIR@']
+          ),
+      ]
 )


### PR DESCRIPTION
This reworks the cibuildwheel code to use pyproject.toml and support local runs with:

```bash
pipx run cibuildwheel --platform linux python
```

And gets rid of some hacks (like touching `setup.py`).
